### PR TITLE
Fix README-FIX command formatting

### DIFF
--- a/README-FIX.md
+++ b/README-FIX.md
@@ -36,7 +36,6 @@
 修正を適用するには、以下の手順に従ってください：
 
 1. `src/types/extractors/improved-xbrl-types.ts` を修正版のファイルで置き換える:
-
 ```bash
 cp src/types/extractors/improved-xbrl-types-modified.ts src/types/extractors/improved-xbrl-types.ts
 ```


### PR DESCRIPTION
## Summary
- keep the `cp` command in README-FIX.md on one line
- remove a blank line preceding the command

## Testing
- `git status --short`